### PR TITLE
Updates platform dependencies

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: 1.2
+  min_ansible_version: 2.8
 
   #
   # Below are all platforms currently available. Just uncomment
@@ -14,15 +14,10 @@ galaxy_info:
   # platform on this list, let us know and we'll get it added!
   #
   platforms:
-    - name: Debian
+    - name: Ubuntu
       versions:
-        - jessie
-
+        - xenial
   galaxy_tags:
     - jira
 
-dependencies:
-  - role: ansiblebit.oracle-java
-    src: git@github.com:ansiblebit/oracle-java.git
-    oracle_java_set_as_default: yes
-    oracle_java_state: present
+dependencies: []


### PR DESCRIPTION
Modifies the role meta vars to declare accurate versions for platform
and Ansible. Also removes the automatic installation of Oracle Java,
so we can manage Java separately from this role, which should just
manage the Atlassian config settings.